### PR TITLE
fix GLM block in p_pdp, data_pdp, p_bpdp, data_bpdp 

### DIFF
--- a/R/data_bpdp.R
+++ b/R/data_bpdp.R
@@ -107,8 +107,10 @@ data_bpdp <-
     }
 
     if (class(model)[1] == "glm") {
-      flt <- grepl("^I\\(", model$terms) | grepl(":", model$terms)
+      flt <- grepl("^I\\(", attr(model$terms, "term.labels")) | 
+        grepl(":", attr(model$terms, "term.labels"))
       flt <- attr(model$terms, "term.labels")[!flt]
+      flt <- flt[flt %in% names(attr(model$terms, "dataClasses"))]
       x <- model$model[flt]
     }
 

--- a/R/data_pdp.R
+++ b/R/data_pdp.R
@@ -108,8 +108,10 @@ data_pdp <-
     }
 
     if (class(model)[1] == "glm") {
-      flt <- grepl("^I\\(", model$terms) | grepl(":", model$terms)
+      flt <- grepl("^I\\(", attr(model$terms, "term.labels")) | 
+        grepl(":", attr(model$terms, "term.labels"))
       flt <- attr(model$terms, "term.labels")[!flt]
+      flt <- flt[flt %in% names(attr(model$terms, "dataClasses"))]
       x <- model$model[flt]
     }
 

--- a/R/p_bpdp.R
+++ b/R/p_bpdp.R
@@ -197,9 +197,10 @@ p_bpdp <-
     }
 
     if (class(model)[1] == "glm") {
-      flt <- grepl("[I(]", attr(model$terms, "term.labels")) |
+      flt <- grepl("^I\\(", attr(model$terms, "term.labels")) | 
         grepl(":", attr(model$terms, "term.labels"))
       flt <- attr(model$terms, "term.labels")[!flt]
+      flt <- flt[flt %in% names(attr(model$terms, "dataClasses"))]
       v <- attr(model$terms, "dataClasses")[flt]
     }
 

--- a/R/p_pdp.R
+++ b/R/p_pdp.R
@@ -131,9 +131,10 @@ p_pdp <-
     }
 
     if (class(model)[1] == "glm") {
-      flt <- grepl("[I(]", attr(model$terms, "term.labels")) |
+      flt <- grepl("^I\\(", attr(model$terms, "term.labels")) | 
         grepl(":", attr(model$terms, "term.labels"))
       flt <- attr(model$terms, "term.labels")[!flt]
+      flt <- flt[flt %in% names(attr(model$terms, "dataClasses"))]
       v <- attr(model$terms, "dataClasses")[flt]
     }
 


### PR DESCRIPTION
Description:
This PR fixes a bug in four functions (p_pdp, data_pdp, p_bpdp, data_bpdp) that caused an error when calling these functions on GLM models fitted with polynomial terms (poly > 0) or interaction terms (inter_order > 0), which is the default behavior of fit_glm.
Error:
Error in `[.data.frame`(model$model, flt) : undefined columns selected
Root cause:
Two issues in the GLM block:

grepl() was being applied to the whole model$terms object instead of attr(model$terms, "term.labels"), returning incorrect results
No check that filtered term names actually exist as column names in the data frame before subsetting

Fix:

Correctly apply grepl() to attr(model$terms, "term.labels")
Add a safety filter flt[flt %in% names(attr(model$terms, "dataClasses"))] before subsetting
Fix inconsistent regex pattern "[I(]" → "^I\\(" in p_pdp and p_bpdp

Tested on R 4.5.2, flexsdm 1.3.9, macOS (ARM64).